### PR TITLE
Generate publish package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,17 +2,18 @@
   "name": "@polycrypt/erdstall",
   "version": "0.1.0",
   "description": "SDK to interact with Erdstall Layer-2 Networks",
+  "main": "./index.js",
   "exports": {
-    ".": "./dist/index.js",
-    "./*": "./dist/*/index.js"
+    ".": "./index.js",
+    "./enclave": "./enclave/index.js",
+    "./api": "./api/index.js",
+    "./api/util": "./api/util/index.js",
+    "./ledger": "./ledger/index.js",
+    "./test": "./test/index.js",
+    "./utils": "./utils/index.js"
   },
   "imports": {
-    "#erdstall/*": "./dist/*/index.js"
-  },
-  "typesVersions": {
-    "*": {
-      "*": [ "dist/*", "dist/*/index.d.ts" ]
-    }
+    "#erdstall/*": "./*/index.js"
   },
   "repository": "github:perun-network/erdstall-ts-sdk",
   "author": "Norbert Dzikowski <norbert@perun.network> (https://polycry.pt/)",
@@ -60,7 +61,9 @@
     "watch": "npx tsc -w",
     "lint": "npx eslint ./src --ext .ts",
     "bindings": "./scripts/genbindings.sh deps/erdstall-contracts",
-    "test": "env TS_NODE_PROJECT=\"tsconfig.test.json\" mocha --timeout 15000 -r jsdom-global/register -r ts-node/register -r tsconfig-paths/register 'src/**/*.spec.ts'"
+    "test": "env TS_NODE_PROJECT=\"tsconfig.test.json\" mocha --timeout 15000 -r jsdom-global/register -r ts-node/register -r tsconfig-paths/register 'src/**/*.spec.ts'",
+    "devpub": "npm run build && npm run postpublish",
+    "postpublish": "npx ts-node ./scripts/publish_posthook.ts ./package.json ./dist/package.json"
   },
   "dependencies": {
     "ethers": "^5.4.1",

--- a/scripts/publish_posthook.ts
+++ b/scripts/publish_posthook.ts
@@ -1,0 +1,44 @@
+"use strict";
+import { readFileSync, writeFileSync } from "fs";
+
+const args = process.argv;
+if (args.length != 4) {
+	console.error(`Please specifiy the base 'package.json' and destination.
+
+  USAGE:
+  ${args[1]} <path-to-base-package.json> <destination-publish.package.json>
+    `);
+	process.exit(1);
+}
+
+const pathToJSON = args[2];
+const publishDestination = args[3];
+const basePackageJSON = JSON.parse(readFileSync(pathToJSON).toString());
+
+// Doing explicit whitelisting, so the development `package.json` can get more
+// and more fields if necessary without leaking information in the published
+// version.
+let publishPackageJSON = {
+	name: basePackageJSON.name,
+	version: basePackageJSON.version,
+	description: basePackageJSON.description,
+	main: basePackageJSON.main,
+	exports: basePackageJSON.exports,
+	imports: basePackageJSON.imports,
+	repository: basePackageJSON.repository,
+	author: basePackageJSON.author,
+	contributors: basePackageJSON.contributors,
+	license: basePackageJSON.license,
+	private: basePackageJSON.private,
+	dependencies: basePackageJSON.dependencies,
+};
+
+try {
+	writeFileSync(
+		publishDestination,
+		JSON.stringify(publishPackageJSON, null, 2),
+	);
+} catch (err) {
+	console.error(`Unable to write package.json: ${err}`);
+	process.exit(1);
+}


### PR DESCRIPTION
1. Introduces a script which can be used to  generate a `package.json` for the distributed module.
2. Adapts the current `src/package.json` to support `{npm run|yarn}` commands to generate the required `package.json`, as well as adapt the `exports` and `imports` fields.
3. Removes some redundant reexports from the top level `src/index.ts`.
4. Fixes a nasty bug only happening in production regarding the calculation of `maxUint256`.