### PR TITLE
Split Client/Session, Reader/Writer

### DIFF
--- a/src/e2e/sdk_remote_integration.spec.ts
+++ b/src/e2e/sdk_remote_integration.spec.ts
@@ -2,12 +2,11 @@
 "use strict";
 
 import { TxReceipt } from "#erdstall/api/responses";
-import { Mint } from "#erdstall/api/transactions";
 import { Address } from "#erdstall/ledger";
 import { Assets } from "#erdstall/ledger/assets";
 import * as assets from "#erdstall/ledger/assets";
 import * as sdk from "#erdstall";
-import { Erdstall } from "#erdstall";
+import { Session } from "#erdstall";
 
 import { ethers } from "ethers";
 import * as fs from "fs";
@@ -56,15 +55,15 @@ describe("Erdstall-TS-SDK", () => {
 	});
 	after(async() => erdstallProcessTerminate);
 
-	function makeClient(index: number): Erdstall {
+	function makeClient(index: number): Session {
 		const provider = new ethers.providers.JsonRpcProvider(`http://localhost:${nodePort}`);
 		const derivationPath = `m/44'/60'/0'/0/${index+2}`;
 		const user = ethers.Wallet.fromMnemonic(mnemonic, derivationPath);
 		const userAddr = Address.fromString(user.address);
-		return sdk.NewClient(userAddr, user.connect(provider), opAddr);
+		return new Session(userAddr, user.connect(provider), opAddr);
 	}
 
-	const clients: Erdstall[] = [];
+	const clients: Session[] = [];
 
 	it("create clients", async() => {
 		for(let i = 0; i < 4; i++)
@@ -76,7 +75,7 @@ describe("Erdstall-TS-SDK", () => {
 		return Promise.all(clients.map(x => x.initialize()));
 	});
 	it("subscribe clients", async() => Promise.all(
-		clients.map(c => c.subscribe())));
+		clients.map(c => c.subscribeSelf())));
 
 	it("deposits", async() => {
 		const depositBal = new Assets({

--- a/src/ledger/backend/connection.spec.ts
+++ b/src/ledger/backend/connection.spec.ts
@@ -7,7 +7,7 @@ import { ETHZERO, Assets, Amount } from "#erdstall/ledger/assets";
 import { EventHelper } from "#erdstall/utils";
 
 import { Erdstall__factory } from "./contracts";
-import { LedgerAdapter } from "./connection";
+import { LedgerWriteConn } from "./writeconn";
 import setup, { Enviroment } from "./enviroment.spec";
 
 describe("ErdstallConnection", () => {
@@ -28,7 +28,7 @@ describe("ErdstallConnection", () => {
 			testenv.users[BOB],
 		);
 
-		const conn = new LedgerAdapter(contract);
+		const conn = new LedgerWriteConn(contract);
 		const depositRegistered = EventHelper.within(10000, conn, "Deposited");
 
 		const stages = await conn.deposit(assets);

--- a/src/ledger/backend/index.ts
+++ b/src/ledger/backend/index.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 "use strict";
 
-export * from "./connection";
+export * from "./readconn";
+export * from "./writeconn";
 export * from "./contracts";
 export * from "./contracts_deposit";
 export * from "./tokencache";

--- a/src/ledger/backend/readconn.ts
+++ b/src/ledger/backend/readconn.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+"use strict";
+
+import { ErdstallWatcher } from "#erdstall";
+import { Address, ErdstallEvent } from "#erdstall/ledger";
+import { Erdstall } from "./contracts/Erdstall";
+
+export const ErrUnsupportedLedgerEvent = new Error(
+	"unsupported ledger event encountered",
+);
+export const ErrErdstallContractNotConnected = new Error(
+	"erdstall contract not connected",
+);
+
+// LedgerConnection describes the connection a client can have to the on-chain
+// part of Erdstall.
+export interface LedgerReader extends ErdstallWatcher {
+	erdstall(): Address;
+}
+
+export class LedgerReadConn implements LedgerReader {
+	readonly contract: Erdstall;
+	private eventCache: Map<Function, (args: Array<any>) => void>;
+
+	constructor(contract: Erdstall) {
+		this.contract = contract;
+		this.eventCache = new Map<Function, (args: Array<any>) => void>();
+	}
+
+	on(ev: ErdstallEvent, cb: Function): void {
+		const wrappedCB = (args: Array<any>) => {
+			cb(args);
+		};
+		this.eventCache.set(cb, wrappedCB);
+		this.contract.on(ev, wrappedCB);
+	}
+
+	once(ev: ErdstallEvent, cb: Function): void {
+		this.contract.once(ev, (args: Array<any>) => {
+			cb(args);
+		});
+	}
+
+	off(ev: ErdstallEvent, cb: Function): void {
+		if (!this.eventCache.has(cb)) {
+			return;
+		}
+		this.contract.off(ev, this.eventCache.get(cb)!);
+		this.eventCache.delete(cb);
+	}
+
+	erdstall(): Address {
+		return Address.fromString(this.contract.address);
+	}
+}

--- a/src/ledger/index.ts
+++ b/src/ledger/index.ts
@@ -5,4 +5,5 @@ export * from "./account";
 export * from "./address";
 export * from "./event";
 
-export * from "./backend/connection";
+export * from "./backend/readconn";
+export * from "./backend/writeconn";

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+"use strict";
+
+import { ethers, Signer } from "ethers";
+
+import { TxReceipt, BalanceProof } from "#erdstall/api/responses";
+import { Transfer, Mint, ExitRequest, TradeOffer, Trade } from "#erdstall/api/transactions";
+import { EnclaveWriter, Enclave } from "#erdstall/enclave";
+import { Address, LedgerWriter } from "#erdstall/ledger";
+import { Assets } from "#erdstall/ledger/assets";
+import { Uint256 } from "#erdstall/api/util";
+import { Stages } from "#erdstall/utils";
+import { ErdstallSession } from "./erdstall";
+import { Client } from "./client";
+
+export const ErrUnitialisedClient = new Error("client unitialised");
+
+export class Session extends Client implements ErdstallSession {
+	readonly address: Address;
+	private nonce: bigint;
+	private readonly enclaveWriter: EnclaveWriter;
+	private readonly signer: Signer;
+
+	constructor(address: Address, signer: Signer, enclave: EnclaveWriter | URL) {
+		super(signer, enclave);
+		this.enclaveWriter = this.enclaveConn as EnclaveWriter;
+		this.signer = signer;
+		this.address = address;
+		this.nonce = 1n;
+		this.enclaveWriter.on("error", () => { this.updateNonce(); });
+	}
+
+	private async nextNonce(): Promise<bigint> {
+		if (this.nonce === 1n) {
+			await this.updateNonce();
+		}
+
+		return this.nonce++;
+	}
+
+	private async updateNonce(): Promise<void> {
+		const acc = await this.enclaveWriter.getAccount(this.address);
+		this.nonce = acc.account.nonce.valueOf() + 1n;
+	}
+
+	async onboard(): Promise<void> {
+		return this.enclaveWriter.onboard(this.address);
+	}
+
+	async subscribeSelf(): Promise<void> {
+		return this.subscribe(this.address);
+	}
+
+	async transferTo(assets: Assets, to: Address): Promise<TxReceipt> {
+		if (!this.erdstallConn) {
+			return Promise.reject(ErrUnitialisedClient);
+		}
+		const tx = new Transfer(
+			this.address,
+			await this.nextNonce(),
+			to,
+			assets,
+		);
+		await tx.sign(this.erdstallConn.erdstall(), this.signer);
+		return this.enclaveWriter.transfer(tx);
+	}
+
+	async mint(token: Address, id: Uint256): Promise<TxReceipt> {
+		if (!this.erdstallConn) {
+			return Promise.reject(ErrUnitialisedClient);
+		}
+
+		const minttx = new Mint(
+			this.address,
+			await this.nextNonce(),
+			token,
+			id,
+		);
+		await minttx.sign(this.erdstallConn.erdstall(), this.signer);
+		return this.enclaveWriter.mint(minttx);
+	}
+
+	async deposit(
+		assets: Assets,
+	): Promise<Stages<Promise<ethers.ContractTransaction>>> {
+		if (!this.erdstallConn) {
+			return Promise.reject(ErrUnitialisedClient);
+		}
+
+		return (this.erdstallConn as LedgerWriter).deposit(assets);
+	}
+
+	async exit(): Promise<BalanceProof> {
+		if (!this.erdstallConn) {
+			return Promise.reject(ErrUnitialisedClient);
+		}
+
+		const exittx = new ExitRequest(this.address, await this.nextNonce());
+		await exittx.sign(this.erdstallConn.erdstall(), this.signer);
+		return this.enclaveWriter.exit(exittx);
+	}
+
+	async withdraw(
+		exitProof: BalanceProof,
+	): Promise<Stages<Promise<ethers.ContractTransaction>>> {
+		if (!this.erdstallConn) {
+			return Promise.reject(ErrUnitialisedClient);
+		}
+
+		return (this.erdstallConn as LedgerWriter).withdraw(exitProof);
+	}
+
+	async leave(): Promise<Stages<Promise<ethers.ContractTransaction>>> {
+		const exitProof = await this.exit();
+		await new Promise(accept => this.once("phaseshift", accept));
+		return this.withdraw(exitProof);
+	}
+
+	async createOffer(offer: Assets, expect: Assets): Promise<TradeOffer> {
+		const o = new TradeOffer(this.address, offer, expect);
+		return o.sign(this.erdstallConn!.erdstall(), this.signer);
+	}
+
+	async acceptTrade(offer: TradeOffer): Promise<TxReceipt> {
+		const tx = new Trade(this.address, await this.nextNonce(), offer);
+		await tx.sign(this.erdstallConn!.erdstall(), this.signer);
+		return this.enclaveWriter.trade(tx);
+	}
+}


### PR DESCRIPTION
Current Changes:
- Session can be created from client, currently reuses the same
  websocket connection, so it would be shared among instances. Sessions
  should re-expose everything from Clients (including unbound
  subscriptions). Sessions also share their event handlers with clients.
- Diversified subscription interfaces, now there are Subscriber
  (subscribeFor(Address), subscribeAll()), and BoundSubscriber
  (subscribe()).

TODO:
- Split ledger connection into LedgerReader/LedgerWriter.
- Figure out whether to share websocket connections or not.
- Figure out: should sessions have completely separate event tracking?
- Figure out: should a single client be used to host multiple
  *independent* sessions, or at most one?