### PR TITLE
Test watcher and newRandom{Wallet,Trade{,Offer}}

### DIFF
--- a/src/api/sig.spec.ts
+++ b/src/api/sig.spec.ts
@@ -3,20 +3,18 @@
 
 import "reflect-metadata";
 import { expect } from "chai";
-import { MockProvider } from "ethereum-waffle";
 import { Address } from "#erdstall/ledger";
 import * as test from "#erdstall/test";
 
-const gProvider = new MockProvider();
-const wallets = gProvider.getWallets();
-
 describe("Signatures", () => {
 	const rng = test.NewPrng();
+	const wallet = test.newRandomWallet(rng);
+
 	it("works for transactions", async () => {
 		const contract = test.NewRandomAddress(rng);
 		const tx = test.NewRandomTransfer(rng, 1);
-		tx.sender = Address.fromString(wallets[0].address);
-		await tx.sign(contract, wallets[0]);
+		tx.sender = Address.fromString(wallet.address);
+		await tx.sign(contract, wallet);
 
 		expect(tx.verify(contract)).to.be.true;
 	});
@@ -24,8 +22,8 @@ describe("Signatures", () => {
 	it("works for mints", async () => {
 		const contract = test.NewRandomAddress(rng);
 		const tx = test.NewRandomMint(rng);
-		tx.sender = Address.fromString(wallets[0].address);
-		await tx.sign(contract, wallets[0]);
+		tx.sender = Address.fromString(wallet.address);
+		await tx.sign(contract, wallet);
 		expect(tx.verify(contract)).to.be.true;
 	});
 });

--- a/src/test/address.ts
+++ b/src/test/address.ts
@@ -2,15 +2,8 @@
 "use strict";
 
 import { Address } from "#erdstall/ledger";
-import PRNG from "./random";
+import PRNG, { NewRandomUint8Array } from "./random";
 
 export function NewRandomAddress(rng: PRNG): Address {
 	return new Address(NewRandomUint8Array(rng, 20));
-}
-
-export function NewRandomUint8Array(rng: PRNG, size: number): Uint8Array {
-	const arr = new Uint8Array(size).fill(0).map((_, __, ___) => {
-		return Math.floor(rng.uFloat32() * 255);
-	});
-	return arr;
 }

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 "use strict";
 
-export * from "./assets";
+export * from "./account";
 export * from "./address";
+export * from "./assets";
 export * from "./bigint";
+export * from "./proofs";
 export * from "./random";
 export * from "./transactions/transactions";
-export * from "./account";
-export * from "./proofs";
+export * from "./wallet";
 export * from "./watcher";

--- a/src/test/proofs.ts
+++ b/src/test/proofs.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 "use strict";
 
-import PRNG from "./random";
+import PRNG, { NewRandomUint8Array  } from "./random";
 import { Signature } from "#erdstall/api";
 import { Balance, BalanceProof, BalanceProofs } from "#erdstall/api/responses";
 import { NewUint64 } from "./bigint";
-import { NewRandomAddress, NewRandomUint8Array } from "./address";
+import { NewRandomAddress } from "./address";
 import { NewRandomAssets } from "./assets";
 
 export function NewRandomBalance(rng: PRNG, size: number): Balance {

--- a/src/test/random.ts
+++ b/src/test/random.ts
@@ -14,6 +14,13 @@ export function NewPrng(): PRNG {
 	if (!seed) {
 		seed = new Date().getTime();
 	}
-	console.log(`PRNG with SEED: ${seed}`);
+	console.log(`PRNG with ESSEED=${seed}`);
 	return aleaRNGFactory(seed);
+}
+
+export function NewRandomUint8Array(rng: PRNG, size: number): Uint8Array {
+	const arr = new Uint8Array(size).fill(0).map((_, __, ___) => {
+		return rng.uInt32() % 0xff;
+	});
+	return arr;
 }

--- a/src/test/transactions/transactions.ts
+++ b/src/test/transactions/transactions.ts
@@ -8,6 +8,8 @@ import {
 	Transfer,
 	ExitRequest,
 	Transaction,
+	TradeOffer,
+	Trade,
 } from "#erdstall/api/transactions";
 
 export function NewRandomMint(rng: PRNG): Mint {
@@ -19,7 +21,7 @@ export function NewRandomMint(rng: PRNG): Mint {
 	);
 }
 
-export function NewRandomTransfer(rng: PRNG, size: number): Transfer {
+export function NewRandomTransfer(rng: PRNG, size: number = 1): Transfer {
 	return new Transfer(
 		NewRandomAddress(rng),
 		NewUint64(rng),
@@ -32,7 +34,25 @@ export function NewRandomExitRequest(rng: PRNG): ExitRequest {
 	return new ExitRequest(NewRandomAddress(rng), NewUint64(rng));
 }
 
-export function NewRandomTransaction(rng: PRNG, size: number): Transaction {
+// Returns an unsigned random TradeOffer.
+export function newRandomTradeOffer(rng: PRNG, size: number = 1): TradeOffer {
+	return new TradeOffer(
+		NewRandomAddress(rng),
+		NewRandomAssets(rng, size),
+		NewRandomAssets(rng, size),
+	);
+}
+
+// Returns an unsigned random Trade with an unsigned random TradeOffer.
+export function newRandomTrade(rng: PRNG, size: number = 1): Trade {
+	return new Trade(
+		NewRandomAddress(rng),
+		NewUint64(rng),
+		newRandomTradeOffer(rng, size),
+	)
+}
+
+export function NewRandomTransaction(rng: PRNG, size: number = 1): Transaction {
 	const calls = [
 		(): Transaction => NewRandomMint(rng),
 		(): Transaction => NewRandomTransfer(rng, size),

--- a/src/test/wallet.ts
+++ b/src/test/wallet.ts
@@ -4,7 +4,7 @@ import PRNG, { NewRandomUint8Array } from "./random";
 import { entropyToMnemonic } from "@ethersproject/hdnode";
 import { Wallet } from "@ethersproject/wallet";
 
-export function newRandomWallet(rng: PRNG) {
+export function newRandomWallet(rng: PRNG): Wallet {
 	const entropy = NewRandomUint8Array(rng, 32);
 	const mnemonic = entropyToMnemonic(entropy);
 	return Wallet.fromMnemonic(mnemonic);

--- a/src/test/wallet.ts
+++ b/src/test/wallet.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import PRNG, { NewRandomUint8Array } from "./random";
+import { entropyToMnemonic } from "@ethersproject/hdnode";
+import { Wallet } from "@ethersproject/wallet";
+
+export function newRandomWallet(rng: PRNG) {
+	const entropy = NewRandomUint8Array(rng, 32);
+	const mnemonic = entropyToMnemonic(entropy);
+	return Wallet.fromMnemonic(mnemonic);
+}


### PR DESCRIPTION
This PR moves the MockWatcher from `nerd-marketplace` into the SDK as a reusable component in testing.

It also creates new randomizer functions `newRandom{Wallet,Trade{,Offer}}` and improves the implementation of `NewRandomUint8Array`.