### PR TITLE
transactions/trade: Change `**` logic to equivalent `<<` logic

### DIFF
--- a/src/api/transactions/trade.ts
+++ b/src/api/transactions/trade.ts
@@ -43,7 +43,7 @@ export class TradeOffer {
 		this.owner = owner;
 		this.offer = offer;
 		this.request = request;
-		this.expiry = new BigInteger(2n**64n - 1n); // For now, never expire.
+		this.expiry = new BigInteger((1n << 64n) - 1n); // For now, never expire.
 	}
 
 	async sign(contract: Address, signer: Signer): Promise<this> {


### PR DESCRIPTION
There is a problem in production, where trying to take the power of a
bigint with another bigints just fails with the message:

Error: Could not convert BigInt to Number.

This is a workaround for this issue.