### PR TITLE
test: Fix and change newRandomBigInt

### DIFF
--- a/src/test/bigint.spec.ts
+++ b/src/test/bigint.spec.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "assert";
+
+import { NewPrng } from "./random";
+import { newRandomBigInt } from "./bigint";
+
+const NUM_TRIES = 128;
+
+describe("newRandomBigInt", function () {
+	const rng = NewPrng();
+
+	function itShouldGenerateProperSize(bits: number) {
+		it(`shold generate numbers of correct size ${bits}`, function () {
+			let maxSizeSeen = false;
+			for (let i = 0; i < NUM_TRIES; i++) {
+				const x = newRandomBigInt(rng, bits);
+				assert.ok(
+					x < 1n << BigInt(bits),
+					`${x} has more than ${bits} bits`,
+				);
+				maxSizeSeen ||= x >> (BigInt(bits) - 1n) > 0n;
+			}
+			// It is very unlikely (1 : 2**NUM_TRIES) that all generated numbers have
+			// the most significant bit _not_ set.
+			assert.ok(
+				maxSizeSeen,
+				`always less than ${bits} bits after ${NUM_TRIES} tries`,
+			);
+		});
+	}
+
+	for (const i of [1, 7, 8, 9, 31, 32, 33, 255, 256, 257]) {
+		itShouldGenerateProperSize(i);
+	}
+});

--- a/src/test/bigint.ts
+++ b/src/test/bigint.ts
@@ -3,26 +3,29 @@
 
 import PRNG from "./random";
 
-// NewBigInt generates a random `BigInt` in range 0 <= `CEIL`.
-export function NewBigInt(rng: PRNG, CEIL: bigint): bigint {
-	const base = CEIL / 2n;
-	const offset = (BigInt(Math.floor(100 * rng.uFloat32())) * base) / 100n;
-	const add = (v1: bigint, v2: bigint): bigint => {
-		return v1 + v2;
-	};
-	const sub = (v1: bigint, v2: bigint): bigint => {
-		return v1 - v2;
-	};
-	const op = rng.uFloat32() < 0.5 ? add : sub;
-	return op(base, offset);
+// newRandomBigInt generates a random `BigInt` with max. `maxBits` number of
+// bits.
+export function newRandomBigInt(rng: PRNG, maxBits: number): bigint {
+	const numInts = Math.trunc(maxBits / 32);
+	let x = 0n;
+	for (let i = 0; i < numInts; ++i) {
+		x += BigInt(rng.uInt32()) << BigInt(i * 32);
+	}
+	const restBits = maxBits % 32;
+	if (restBits > 0) {
+		x +=
+			BigInt(rng.uInt32() & ((1 << restBits) - 1)) <<
+			BigInt(numInts * 32);
+	}
+	return x;
 }
 
 // NewUint256 generates a random bigint with 256 bit precision.
 export function NewUint256(rng: PRNG): bigint {
-	return BigInt.asUintN(256, NewBigInt(rng, 2n ** 256n));
+	return newRandomBigInt(rng, 256);
 }
 
 // NewUint64 generates a random bigint with 64 bit precision.
 export function NewUint64(rng: PRNG): bigint {
-	return BigInt.asUintN(64, NewBigInt(rng, 2n ** 64n));
+	return newRandomBigInt(rng, 64);
 }


### PR DESCRIPTION
- The second parameter is now the number of bits, not the max value.
- newRandomBigInt was called NewBigInt before. Renamed it to make sure
that all users of this function update their call. We wanted to rename
it anyways.
