### PR TITLE
Lift `TokenTypesCache` into `ErdstallClient`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -14,13 +14,13 @@ import {
 	ErdstallEvent,
 	isLedgerEvent,
 } from "#erdstall/ledger";
-import { TokenTypesCache, TokenCache } from "#erdstall/ledger/backend";
+import { TokenFetcher, TokenProvider } from "#erdstall/ledger/backend";
 import { EventCache, OneShotEventCache } from "#erdstall/utils";
 import { ethers, Signer } from "ethers";
 import { NFTMetadata } from "#erdstall/ledger/backend";
 
 export class Client implements ErdstallClient {
-	readonly tokenCache: TokenCache;
+	readonly tokenProvider: TokenProvider;
 	protected enclaveConn: EnclaveReader;
 	protected provider: ethers.providers.Provider | Signer;
 	protected erdstallConn?: LedgerReader | LedgerWriter;
@@ -38,7 +38,7 @@ export class Client implements ErdstallClient {
 		this.erdstallEventHandlerCache = new EventCache<ErdstallEvent>();
 		this.erdstallOneShotHandlerCache =
 			new OneShotEventCache<ErdstallEvent>();
-		this.tokenCache = new TokenTypesCache();
+		this.tokenProvider = new TokenFetcher();
 	}
 
 	erdstall(): Address {
@@ -114,7 +114,7 @@ export class Client implements ErdstallClient {
 				);
 				this.erdstallConn = new LedgerWriteConn(
 					erdstall,
-					this.tokenCache,
+					this.tokenProvider,
 				);
 
 				for (const [ev, cbs] of this.erdstallEventHandlerCache) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -14,11 +14,13 @@ import {
 	ErdstallEvent,
 	isLedgerEvent,
 } from "#erdstall/ledger";
+import { TokenTypesCache, TokenCache } from "#erdstall/ledger/backend";
 import { EventCache, OneShotEventCache } from "#erdstall/utils";
 import { ethers, Signer } from "ethers";
 import { NFTMetadata } from "#erdstall/ledger/backend";
 
 export class Client implements ErdstallClient {
+	readonly tokenCache: TokenCache;
 	protected enclaveConn: EnclaveReader;
 	protected provider: ethers.providers.Provider | Signer;
 	protected erdstallConn?: LedgerReader | LedgerWriter;
@@ -36,6 +38,7 @@ export class Client implements ErdstallClient {
 		this.erdstallEventHandlerCache = new EventCache<ErdstallEvent>();
 		this.erdstallOneShotHandlerCache =
 			new OneShotEventCache<ErdstallEvent>();
+		this.tokenCache = new TokenTypesCache();
 	}
 
 	erdstall(): Address {
@@ -109,7 +112,10 @@ export class Client implements ErdstallClient {
 					config.contract.toString(),
 					this.provider,
 				);
-				this.erdstallConn = new LedgerWriteConn(erdstall);
+				this.erdstallConn = new LedgerWriteConn(
+					erdstall,
+					this.tokenCache,
+				);
 
 				for (const [ev, cbs] of this.erdstallEventHandlerCache) {
 					cbs.forEach((cb) => {

--- a/src/erdstall.ts
+++ b/src/erdstall.ts
@@ -10,6 +10,7 @@ import { TxReceipt } from "#erdstall/api/responses";
 import { TradeOffer } from "#erdstall/api/transactions";
 import { BalanceProof } from "#erdstall/api/responses";
 import { Address, Account, ErdstallEvent } from "#erdstall/ledger";
+import { TokenCache } from "#erdstall/ledger/backend";
 import { Assets } from "#erdstall/ledger/assets";
 import { Uint256 } from "#erdstall/api/util";
 import { Stages } from "#erdstall/utils";
@@ -105,7 +106,9 @@ export interface ErdstallClient
 		Initializer,
 		Subscriber,
 		NFTMetadataProvider,
-		AccountGetter {}
+		AccountGetter {
+	readonly tokenCache: TokenCache;
+}
 
 export interface ErdstallSession
 	extends ErdstallClient,

--- a/src/erdstall.ts
+++ b/src/erdstall.ts
@@ -10,7 +10,7 @@ import { TxReceipt } from "#erdstall/api/responses";
 import { TradeOffer } from "#erdstall/api/transactions";
 import { BalanceProof } from "#erdstall/api/responses";
 import { Address, Account, ErdstallEvent } from "#erdstall/ledger";
-import { TokenCache } from "#erdstall/ledger/backend";
+import { TokenProvider } from "#erdstall/ledger/backend";
 import { Assets } from "#erdstall/ledger/assets";
 import { Uint256 } from "#erdstall/api/util";
 import { Stages } from "#erdstall/utils";
@@ -107,7 +107,7 @@ export interface ErdstallClient
 		Subscriber,
 		NFTMetadataProvider,
 		AccountGetter {
-	readonly tokenCache: TokenCache;
+	readonly tokenProvider: TokenProvider;
 }
 
 export interface ErdstallSession

--- a/src/ledger/backend/connection.spec.ts
+++ b/src/ledger/backend/connection.spec.ts
@@ -11,7 +11,7 @@ import { Balance } from "#erdstall/api/responses";
 
 import { Erdstall__factory, Erdstall } from "./contracts";
 import { LedgerWriteConn, LedgerWriter } from "./writeconn";
-import { TokenTypesCache } from "./tokencache";
+import { TokenFetcher } from "./tokencache";
 import { Environment, setupEnv } from "#erdstall/test/ledger";
 
 import * as test from "#erdstall/test";
@@ -41,7 +41,7 @@ describe("ErdstallConnection", () => {
 		assets.addAsset(ETHZERO, amount);
 		assets.addAsset(testenv.perunArt, tokens);
 		contract = Erdstall__factory.connect(testenv.erdstall, bob);
-		conn = new LedgerWriteConn(contract, new TokenTypesCache());
+		conn = new LedgerWriteConn(contract, new TokenFetcher());
 	});
 
 	it("allows depositing into the erdstall contract", async () => {

--- a/src/ledger/backend/connection.spec.ts
+++ b/src/ledger/backend/connection.spec.ts
@@ -11,6 +11,7 @@ import { Balance } from "#erdstall/api/responses";
 
 import { Erdstall__factory, Erdstall } from "./contracts";
 import { LedgerWriteConn, LedgerWriter } from "./writeconn";
+import { TokenTypesCache } from "./tokencache";
 import { Environment, setupEnv } from "#erdstall/test/ledger";
 
 import * as test from "#erdstall/test";
@@ -40,7 +41,7 @@ describe("ErdstallConnection", () => {
 		assets.addAsset(ETHZERO, amount);
 		assets.addAsset(testenv.perunArt, tokens);
 		contract = Erdstall__factory.connect(testenv.erdstall, bob);
-		conn = new LedgerWriteConn(contract);
+		conn = new LedgerWriteConn(contract, new TokenTypesCache());
 	});
 
 	it("allows depositing into the erdstall contract", async () => {

--- a/src/ledger/backend/readconn.ts
+++ b/src/ledger/backend/readconn.ts
@@ -3,6 +3,7 @@
 
 import { ErdstallWatcher, Contracter } from "#erdstall";
 import { Address, ErdstallEvent } from "#erdstall/ledger";
+import { TokenCache } from "./tokencache";
 import { Erdstall } from "./contracts/Erdstall";
 import { NFTMetadata, NFTMetadataProvider } from "./metadata";
 import { IERC721Metadata__factory } from "./contracts";
@@ -24,11 +25,13 @@ export class LedgerReadConn implements LedgerReader {
 	readonly contract: Erdstall;
 	private eventCache: Map<Function, (args: Array<any>) => void>;
 	private metadataCache: Map<string, NFTMetadata>;
+	readonly tokenCache: TokenCache;
 
-	constructor(contract: Erdstall) {
+	constructor(contract: Erdstall, tokenCache: TokenCache) {
 		this.contract = contract;
 		this.eventCache = new Map();
 		this.metadataCache = new Map();
+		this.tokenCache = tokenCache;
 	}
 
 	on(ev: ErdstallEvent, cb: Function): void {

--- a/src/ledger/backend/readconn.ts
+++ b/src/ledger/backend/readconn.ts
@@ -3,7 +3,7 @@
 
 import { ErdstallWatcher, Contracter } from "#erdstall";
 import { Address, ErdstallEvent } from "#erdstall/ledger";
-import { TokenCache } from "./tokencache";
+import { TokenProvider } from "./tokencache";
 import { Erdstall } from "./contracts/Erdstall";
 import { NFTMetadata, NFTMetadataProvider } from "./metadata";
 import { IERC721Metadata__factory } from "./contracts";
@@ -25,9 +25,9 @@ export class LedgerReadConn implements LedgerReader {
 	readonly contract: Erdstall;
 	private eventCache: Map<Function, (args: Array<any>) => void>;
 	private metadataCache: Map<string, NFTMetadata>;
-	readonly tokenCache: TokenCache;
+	readonly tokenCache: TokenProvider;
 
-	constructor(contract: Erdstall, tokenCache: TokenCache) {
+	constructor(contract: Erdstall, tokenCache: TokenProvider) {
 		this.contract = contract;
 		this.eventCache = new Map();
 		this.metadataCache = new Map();

--- a/src/ledger/backend/tokencache.spec.ts
+++ b/src/ledger/backend/tokencache.spec.ts
@@ -6,7 +6,7 @@ import { Wallet } from "ethers";
 
 import { Erdstall__factory } from "./contracts";
 import { TokenType, ETHZERO } from "#erdstall/ledger/assets";
-import { TokenTypesCache } from "./tokencache";
+import { TokenFetcher } from "./tokencache";
 
 import { Environment, setupEnv } from "#erdstall/test/ledger";
 
@@ -21,7 +21,7 @@ describe("Tokencache", () => {
 
 	it("fetches registered tokens and tokenholders from erdstall", async () => {
 		const erdstall = Erdstall__factory.connect(testenv.erdstall, bob);
-		const cache = new TokenTypesCache();
+		const cache = new TokenFetcher();
 
 		const testInputHolders = [
 			["ETH", testenv.ethHolder],

--- a/src/ledger/backend/tokencache.ts
+++ b/src/ledger/backend/tokencache.ts
@@ -20,9 +20,7 @@ interface Responder {
 	symbol(): Promise<string>;
 }
 
-export interface TokenCache {
-	readonly typeCache: TokenTypes;
-	readonly holderCache: TokenHolders;
+export interface TokenProvider {
 	setType(tokenAddr: string, ttype: TokenType): void;
 	tokenHolderFor(erdstall: Erdstall, ttype: TokenType): Promise<string>;
 	tokenTypeOf(erdstall: Erdstall, tokenAddr: string): Promise<TokenType>;
@@ -44,7 +42,7 @@ export interface TokenCache {
 type TokenTypes = Map<string, TokenType>;
 type TokenHolders = Map<TokenType, string>;
 
-export class TokenTypesCache implements TokenCache {
+export class TokenFetcher implements TokenProvider {
 	readonly typeCache: TokenTypes;
 	readonly holderCache: TokenHolders;
 	private bigbang?: number;

--- a/src/ledger/backend/tokencache.ts
+++ b/src/ledger/backend/tokencache.ts
@@ -20,10 +20,31 @@ interface Responder {
 	symbol(): Promise<string>;
 }
 
+export interface TokenCache {
+	readonly typeCache: TokenTypes;
+	readonly holderCache: TokenHolders;
+	setType(tokenAddr: string, ttype: TokenType): void;
+	tokenHolderFor(erdstall: Erdstall, ttype: TokenType): Promise<string>;
+	tokenTypeOf(erdstall: Erdstall, tokenAddr: string): Promise<TokenType>;
+	findRegisteredTokenWithSymbol(
+		erdstall: Erdstall,
+		symbol: string,
+		fromBlock?: number,
+	): Promise<string | undefined>;
+	queryRegisteredTokenTypes(
+		erdstall: Erdstall,
+		fromBlock?: number,
+	): Promise<TokenTypeRegisteredEvent[]>;
+	queryRegisteredTokens(
+		erdstall: Erdstall,
+		fromBlock?: number,
+	): Promise<TokenRegisteredEvent[]>;
+}
+
 type TokenTypes = Map<string, TokenType>;
 type TokenHolders = Map<TokenType, string>;
 
-export class TokenTypesCache {
+export class TokenTypesCache implements TokenCache {
 	readonly typeCache: TokenTypes;
 	readonly holderCache: TokenHolders;
 	private bigbang?: number;

--- a/src/ledger/backend/writeconn.ts
+++ b/src/ledger/backend/writeconn.ts
@@ -10,7 +10,7 @@ import { BalanceProof } from "#erdstall/api/responses";
 import { Erdstall } from "./contracts/Erdstall";
 import { LedgerReader, LedgerReadConn } from "./readconn";
 import { depositors, DepositCalls } from "./tokenmanager";
-import { TokenTypesCache } from "./tokencache";
+import { TokenCache } from "./tokencache";
 
 // LedgerConnection describes the connection a client can have to the on-chain
 // part of Erdstall.
@@ -20,11 +20,9 @@ export interface LedgerWriter extends LedgerReader, Depositor, Withdrawer {
 
 export class LedgerWriteConn extends LedgerReadConn implements LedgerWriter {
 	readonly signer: Signer;
-	readonly tokenCache: TokenTypesCache;
 
-	constructor(contract: Erdstall) {
-		super(contract);
-		this.tokenCache = new TokenTypesCache();
+	constructor(contract: Erdstall, tokenCache: TokenCache) {
+		super(contract, tokenCache);
 		this.signer = contract.signer;
 	}
 

--- a/src/ledger/backend/writeconn.ts
+++ b/src/ledger/backend/writeconn.ts
@@ -10,7 +10,7 @@ import { BalanceProof } from "#erdstall/api/responses";
 import { Erdstall } from "./contracts/Erdstall";
 import { LedgerReader, LedgerReadConn } from "./readconn";
 import { depositors, DepositCalls } from "./tokenmanager";
-import { TokenCache } from "./tokencache";
+import { TokenProvider } from "./tokencache";
 
 // LedgerConnection describes the connection a client can have to the on-chain
 // part of Erdstall.
@@ -21,7 +21,7 @@ export interface LedgerWriter extends LedgerReader, Depositor, Withdrawer {
 export class LedgerWriteConn extends LedgerReadConn implements LedgerWriter {
 	readonly signer: Signer;
 
-	constructor(contract: Erdstall, tokenCache: TokenCache) {
+	constructor(contract: Erdstall, tokenCache: TokenProvider) {
 		super(contract, tokenCache);
 		this.signer = contract.signer;
 	}

--- a/src/test/mocks.ts
+++ b/src/test/mocks.ts
@@ -24,7 +24,11 @@ import {
 } from "#erdstall/api/calls";
 import { Transaction } from "#erdstall/api/transactions";
 import { Address, Account, ErdstallEvent } from "#erdstall/ledger";
-import { NFTMetadata } from "#erdstall/ledger/backend";
+import {
+	NFTMetadata,
+	TokenTypesCache,
+	TokenCache,
+} from "#erdstall/ledger/backend";
 import { Assets, Tokens } from "#erdstall/ledger/assets";
 import { EnclaveEvent, EnclaveProvider } from "#erdstall/enclave";
 
@@ -96,6 +100,7 @@ export class MockWatcher implements Watcher {
 }
 
 export class MockClient extends MockWatcher implements ErdstallClient {
+	readonly tokenCache: TokenCache;
 	private readonly contract: Address;
 	private metadata: Map<string, NFTMetadata>;
 
@@ -103,6 +108,7 @@ export class MockClient extends MockWatcher implements ErdstallClient {
 		super();
 		this.contract = contract;
 		this.metadata = new Map();
+		this.tokenCache = new TokenTypesCache();
 	}
 
 	async initialize(): Promise<void> {}

--- a/src/test/mocks.ts
+++ b/src/test/mocks.ts
@@ -26,8 +26,8 @@ import { Transaction } from "#erdstall/api/transactions";
 import { Address, Account, ErdstallEvent } from "#erdstall/ledger";
 import {
 	NFTMetadata,
-	TokenTypesCache,
-	TokenCache,
+	TokenFetcher,
+	TokenProvider,
 } from "#erdstall/ledger/backend";
 import { Assets, Tokens } from "#erdstall/ledger/assets";
 import { EnclaveEvent, EnclaveProvider } from "#erdstall/enclave";
@@ -100,7 +100,7 @@ export class MockWatcher implements Watcher {
 }
 
 export class MockClient extends MockWatcher implements ErdstallClient {
-	readonly tokenCache: TokenCache;
+	readonly tokenProvider: TokenProvider;
 	private readonly contract: Address;
 	private metadata: Map<string, NFTMetadata>;
 
@@ -108,7 +108,7 @@ export class MockClient extends MockWatcher implements ErdstallClient {
 		super();
 		this.contract = contract;
 		this.metadata = new Map();
-		this.tokenCache = new TokenTypesCache();
+		this.tokenProvider = new TokenFetcher();
 	}
 
 	async initialize(): Promise<void> {}


### PR DESCRIPTION
Adds an abstraction for the `TokenTypesCache` called `TokenCache`.
This `TokenCache` is available in `Ledger{Reader|Writer}` and can be externally owned, like the `ErdstallClient` does now.