### PR TITLE
ledger/backend: Make Attribute.trait_type optional

### DIFF
--- a/src/ledger/backend/metadata.ts
+++ b/src/ledger/backend/metadata.ts
@@ -26,7 +26,7 @@ export const displayTypes = [
 export type DisplayType = typeof displayTypes[number];
 
 export interface Attribute {
-	trait_type: string;
+	trait_type?: string;
 	value: string | number;
 	max_value?: number;
 	display_type?: DisplayType;


### PR DESCRIPTION
OpenSea allows generic attributes, which only have a string value.
