### PR TITLE
Improve event cache

### DIFF
--- a/src/enclave/connection.ts
+++ b/src/enclave/connection.ts
@@ -166,22 +166,7 @@ export class Enclave implements EnclaveWriter {
 		eventType: T,
 		cb: ErdstallEventHandler<T>,
 	) {
-		if (!this.handlers.has(eventType)) {
-			return;
-		}
-		const handlers = this.handlers.get(eventType)!;
-		const idx = handlers.indexOf(cb);
-		if (idx === -1) {
-			return;
-		}
-		for (let i = 0; i < handlers.length; i++) {
-			if (i <= idx) {
-				continue;
-			}
-			handlers[i - 1] = handlers[i];
-		}
-		handlers.pop();
-		return;
+		this.handlers.delete(eventType, cb);
 	}
 
 	private nextID(): number {

--- a/src/utils/event_cache.spec.ts
+++ b/src/utils/event_cache.spec.ts
@@ -1,0 +1,83 @@
+import { expect } from "chai";
+import { OneShotEventCache, EventCache } from "./event_cache";
+import { ErdstallEvent, ErdstallEventHandler } from "#erdstall";
+import * as test from "#erdstall/test";
+
+describe("OneShotEventCache", function () {
+	const rng = test.newPrng();
+	const cbs = [() => 42, () => 69, () => 420];
+	const key = "proof";
+	it("allows setting and removing multiple handlers", function () {
+		const cache = new OneShotEventCache<ErdstallEvent>();
+		cbs.forEach((cb) => cache.set(key, cb));
+		expect(cache.has(key)).to.be.true;
+		expectAllToBe(true, key, cbs, cache);
+		expect(cache.has(key, () => {})).to.be.false;
+
+		expect(cache.delete(key)).to.be.true;
+
+		expectAllToBe(false, key, cbs, cache);
+		expect(cache.has(key)).to.be.false;
+	});
+
+	it("allows deleting specific handlers", function () {
+		const cache = new OneShotEventCache<ErdstallEvent>();
+		cbs.forEach((cb) => cache.set(key, cb));
+		expectAllToBe(true, key, cbs, cache);
+
+		const idx = rng.uInt32() % cbs.length;
+		expect(
+			cache.delete(key, cbs[idx]),
+			`deleting a specific handler should work: ${idx}`,
+		).to.be.true;
+		cbs.forEach((cb, i) => {
+			if (i === idx)
+				expect(
+					cache.has(key, cb),
+					`looking up deleted handler ${idx} should fail`,
+				).to.be.false;
+			else
+				expect(
+					cache.has(key, cb),
+					`not deleted handler ${i} should still exist`,
+				).to.be.true;
+		});
+
+		cache.delete(key);
+		expectAllToBe(false, key, cbs, cache);
+	});
+
+	it("removes all entries for a key when getting", function () {
+		const cache = new OneShotEventCache<ErdstallEvent>();
+		expect(cache.get(key)).to.be.undefined;
+
+		cbs.forEach((cb) => cache.set(key, cb));
+		expectAllToBe(true, key, cbs, cache);
+		expect(cache.get(key)).to.deep.equal(cbs);
+		expectAllToBe(false, key, cbs, cache);
+		expect(cache.has(key)).to.be.false;
+	});
+});
+
+describe("EventCache", function () {
+	const cbs = [() => 42, () => 69, () => 420];
+	const key = "proof";
+	it("does not remove entries when getting", function () {
+		const cache = new EventCache<ErdstallEvent>();
+		expect(cache.get(key)).to.be.undefined;
+
+		cbs.forEach((cb) => cache.set(key, cb));
+		expectAllToBe(true, key, cbs, cache);
+		expect(cache.get(key)).to.deep.equal(cbs);
+		expectAllToBe(true, key, cbs, cache);
+	});
+});
+
+function expectAllToBe(
+	trueOrFalse: boolean,
+	key: ErdstallEvent,
+	collection: ErdstallEventHandler<typeof key>[],
+	cache: OneShotEventCache<typeof key>,
+) {
+	expect(collection.every((cb) => cache.has(key, cb))).to.equal(trueOrFalse);
+}

--- a/src/utils/event_cache.ts
+++ b/src/utils/event_cache.ts
@@ -21,8 +21,32 @@ export class OneShotEventCache<T extends ErdstallEvent>
 		return this;
 	}
 
-	has(key: T): boolean {
-		return this.m.has(key);
+	has(key: T, val?: ErdstallEventHandler<T>): boolean {
+		const events = this.m.get(key);
+		if (events === undefined || !val) {
+			return !!events;
+		}
+
+		return !!events.find((other) => other === val);
+	}
+
+	delete(key: T, val?: ErdstallEventHandler<T>): boolean {
+		const events = this.m.get(key);
+		if (events === undefined) {
+			return false;
+		}
+
+		if (!val) {
+			return this.m.delete(key);
+		}
+
+		const id = events.findIndex((other) => other === val);
+		if (id === -1) {
+			return false;
+		}
+
+		events.splice(id, 1);
+		return true;
 	}
 
 	get(key: T): ErdstallEventHandler<T>[] | undefined {


### PR DESCRIPTION
When adapting our interface to have typesafe eventhandlers, I mistakenly thought I would have to change the implementation of the `LedgerReader`. This was not necessary in the end, but I realised, that the `EventCache` was not tested **AND** had a bug. This is fixed and improved here.