### PR TITLE
Add onChainQuery member to Client, needed for #152 in NERD

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -19,9 +19,12 @@ import { TokenFetcher, TokenProvider } from "#erdstall/ledger/backend";
 import { EventCache, OneShotEventCache } from "#erdstall/utils";
 import { ethers, Signer } from "ethers";
 import { NFTMetadata } from "#erdstall/ledger/backend";
+import { OnChainQuerier } from "./ledger/onChainQuerier";
+import { EthereumOnChainQuerier } from "./ledger/backend/ethereumOnChainQuerier";
 
 export class Client implements ErdstallClient {
 	readonly tokenProvider: TokenProvider;
+	readonly onChainQuerier: OnChainQuerier;
 	protected enclaveConn: EnclaveReader;
 	protected provider: ethers.providers.Provider | Signer;
 	protected erdstallConn?: LedgerReader | LedgerWriter;
@@ -39,6 +42,7 @@ export class Client implements ErdstallClient {
 		this.erdstallEventHandlerCache = new EventCache<LedgerEvent>();
 		this.erdstallOneShotHandlerCache = new OneShotEventCache<LedgerEvent>();
 		this.tokenProvider = new TokenFetcher();
+		this.onChainQuerier = new EthereumOnChainQuerier(this.provider);
 	}
 
 	erdstall(): Address {

--- a/src/erdstall.ts
+++ b/src/erdstall.ts
@@ -16,6 +16,7 @@ import { Uint256 } from "#erdstall/api/util";
 import { Stages } from "#erdstall/utils";
 import { EnclaveEvent } from "#erdstall/enclave";
 import { NFTMetadataProvider } from "#erdstall/ledger/backend";
+import { OnChainQuerier } from "./ledger";
 
 import { ErdstallEvent, ErdstallEventHandler } from "./event";
 export * from "./client";
@@ -109,6 +110,7 @@ export interface ErdstallClient
 		NFTMetadataProvider,
 		AccountGetter {
 	readonly tokenProvider: TokenProvider;
+	readonly onChainQuerier: OnChainQuerier;
 }
 
 export interface ErdstallSession

--- a/src/ledger/backend/ethereumOnChainQuerier.spec.ts
+++ b/src/ledger/backend/ethereumOnChainQuerier.spec.ts
@@ -1,0 +1,148 @@
+"use strict";
+
+import { expect } from "chai";
+import { EthereumOnChainQuerier } from "./ethereumOnChainQuerier";
+import { OnChainQuerier } from "../onChainQuerier";
+
+import * as test from "#erdstall/test";
+import { Environment, setupEnv } from "test/ledger";
+import { Wallet } from "@ethersproject/wallet";
+import { IERC721Minter__factory, IERC721__factory } from ".";
+import { Tokens } from "../assets";
+import PRNG from "#erdstall/test/random";
+import { afterEach } from "mocha";
+
+const PRIMES = [2, 3, 5, 7];
+const TOKEN_SIZE = PRIMES.length;
+const RNG: PRNG = test.newPrng();
+
+interface Entity {
+	wallet: Wallet;
+	tokens: Tokens;
+	runningTokens: bigint[];
+}
+
+describe("EthereumOnChainQuerier", function () {
+	let testenv: Environment;
+	let alice: Entity;
+	let bob: Entity;
+	let onChainQueryA: OnChainQuerier;
+	let aTransferSeed: number;
+	let bTransferSeed: number;
+
+	const initEntity = async (wallet: Wallet): Promise<Entity> => {
+		const tokens = test.newRandomTokens(RNG, TOKEN_SIZE);
+		const entity: Entity = {
+			wallet,
+			tokens,
+			runningTokens: Array.from(tokens.value),
+		};
+
+		const erc721Minter = IERC721Minter__factory.connect(
+			testenv.perunArt,
+			entity.wallet,
+		);
+		let nonce = await entity.wallet.provider.getTransactionCount(
+			entity.wallet.address,
+		);
+		for (const id of entity.tokens.value) {
+			await erc721Minter.mint(entity.wallet.address, id, {
+				nonce: nonce++,
+			});
+		}
+		await testenv.mine();
+
+		return entity;
+	};
+
+	const seededTokenTransfer = async (
+		from: Entity,
+		to: Entity,
+		seed: number,
+		tokenPool: Tokens,
+		mineEachTX: boolean,
+	): Promise<void> => {
+		const ierc721 = IERC721__factory.connect(testenv.perunArt, from.wallet);
+		let nonce = await from.wallet.provider.getTransactionCount(
+			from.wallet.address,
+		);
+		for (let index = 0; index < TOKEN_SIZE; ++index) {
+			if ((seed % PRIMES[index]) % 2 === 0) {
+				const token = tokenPool.value[index];
+				await ierc721.transferFrom(
+					from.wallet.address,
+					to.wallet.address,
+					token,
+					{ nonce: nonce++ },
+				);
+				to.runningTokens.push(token);
+				from.runningTokens.splice(from.runningTokens.indexOf(token), 1);
+				if (mineEachTX) {
+					await testenv.mine();
+				}
+			}
+		}
+		await testenv.mine();
+	};
+
+	before(async function () {
+		testenv = await setupEnv(2, undefined, { blockTime: 1 });
+		alice = await initEntity(testenv.users[0]);
+		bob = await initEntity(testenv.users[1]);
+		onChainQueryA = new EthereumOnChainQuerier(alice.wallet);
+	});
+
+	const transferTest = async (mineEachTX: boolean): Promise<void> => {
+		aTransferSeed = RNG.uInt32();
+		await seededTokenTransfer(
+			alice,
+			bob,
+			aTransferSeed,
+			alice.tokens,
+			mineEachTX,
+		);
+		bTransferSeed = RNG.uInt32();
+		await seededTokenTransfer(
+			bob,
+			alice,
+			bTransferSeed,
+			bob.tokens,
+			mineEachTX,
+		);
+
+		let aliceTokens = await onChainQueryA.queryTokensOwnedByAddress(
+			testenv.perunArt,
+			alice.wallet.address,
+		);
+		expect(aliceTokens.value)
+			.to.have.members(alice.runningTokens)
+			.and.length(alice.runningTokens.length);
+		let bobTokens = await onChainQueryA.queryTokensOwnedByAddress(
+			testenv.perunArt,
+			bob.wallet.address,
+		);
+		expect(bobTokens.value)
+			.to.have.members(bob.runningTokens)
+			.and.length(bob.runningTokens.length);
+	};
+
+	it("correctly returns the tokens in the address' possession after transfers across blocks", async function () {
+		return transferTest(true);
+	});
+
+	it("correctly returns the tokens in the address' possession after single-block transfers", async function () {
+		return transferTest(false);
+	});
+
+	afterEach(async function () {
+		// send the tokens back
+		await seededTokenTransfer(alice, bob, bTransferSeed, bob.tokens, true);
+		await seededTokenTransfer(
+			bob,
+			alice,
+			aTransferSeed,
+			alice.tokens,
+			false,
+		);
+	});
+});

--- a/src/ledger/backend/ethereumOnChainQuerier.ts
+++ b/src/ledger/backend/ethereumOnChainQuerier.ts
@@ -1,0 +1,51 @@
+import { providers, Signer, BigNumber } from "ethers";
+
+import { IERC721__factory } from ".";
+import { Tokens } from "../assets";
+
+import { OnChainQuerier } from "../onChainQuerier";
+import { TypedEvent } from "./contracts/commons";
+
+export class EthereumOnChainQuerier implements OnChainQuerier {
+	readonly provider: providers.Provider | Signer;
+
+	constructor(provider: providers.Provider | Signer) {
+		this.provider = provider;
+	}
+
+	async queryTokensOwnedByAddress(
+		token: string,
+		address: string,
+	): Promise<Tokens> {
+		const erc721 = IERC721__factory.connect(token, this.provider);
+		const outboundFilter = erc721.filters.Transfer(address, null, null);
+		const inboundFilter = erc721.filters.Transfer(null, address, null);
+		const [outbound, inbound] = await Promise.all([
+			erc721.queryFilter(outboundFilter),
+			erc721.queryFilter(inboundFilter),
+		]);
+
+		const ownershipHistory = [
+			...outbound.map((tx) => ({ ...tx, owned: false })),
+			...inbound.map((tx) => ({ ...tx, owned: true })),
+		];
+		ownershipHistory.sort((x, y): number => {
+			const blockDiff = x.blockNumber - y.blockNumber;
+			return blockDiff === 0
+				? x.transactionIndex - y.transactionIndex
+				: blockDiff;
+		});
+
+		const tokenOwnedMemo = new Map<bigint, boolean>();
+
+		for (const entry of ownershipHistory) {
+			tokenOwnedMemo.set(entry.args.tokenId.toBigInt(), entry.owned);
+		}
+
+		const ownedTokens = [];
+		for (let [token, isOwned] of tokenOwnedMemo.entries()) {
+			if (isOwned) ownedTokens.push(token);
+		}
+		return new Tokens(ownedTokens);
+	}
+}

--- a/src/ledger/index.ts
+++ b/src/ledger/index.ts
@@ -4,6 +4,7 @@
 export * from "./account";
 export * from "./address";
 export * from "./event";
+export * from "./onChainQuerier";
 
 export * from "./backend/readconn";
 export * from "./backend/writeconn";

--- a/src/ledger/onChainQuerier.ts
+++ b/src/ledger/onChainQuerier.ts
@@ -1,0 +1,5 @@
+import { Tokens } from "./assets";
+
+export interface OnChainQuerier {
+	queryTokensOwnedByAddress(token: string, address: string): Promise<Tokens>;
+}

--- a/src/test/mocks.ts
+++ b/src/test/mocks.ts
@@ -27,7 +27,7 @@ import {
 	GetAccount,
 } from "#erdstall/api/calls";
 import { Transaction } from "#erdstall/api/transactions";
-import { Address, Account } from "#erdstall/ledger";
+import { Address, Account, OnChainQuerier } from "#erdstall/ledger";
 import {
 	NFTMetadata,
 	TokenFetcher,
@@ -117,6 +117,7 @@ export class MockWatcher implements Watcher {
 
 export class MockClient extends MockWatcher implements ErdstallClient {
 	readonly tokenProvider: TokenProvider;
+	readonly onChainQuerier: OnChainQuerier;
 	private readonly contract: Address;
 	private metadata: Map<string, NFTMetadata>;
 
@@ -125,6 +126,7 @@ export class MockClient extends MockWatcher implements ErdstallClient {
 		this.contract = contract;
 		this.metadata = new Map();
 		this.tokenProvider = new TokenFetcher();
+		this.onChainQuerier = new MockOnChainQuerier();
 	}
 
 	async initialize(): Promise<void> {}
@@ -255,4 +257,14 @@ function newTxReceiptResult(
 	const delta = new Map<string, Account>([[tx.sender.key, _acc]]);
 	const txr = new TxReceipt(tx, delta);
 	return new Result(id, txr);
+}
+
+class MockOnChainQuerier implements OnChainQuerier {
+	constructor() {}
+	async queryTokensOwnedByAddress(
+		_token: string,
+		_address: string,
+	): Promise<Tokens> {
+		return new Tokens([]);
+	}
 }


### PR DESCRIPTION
This PR introduces a new `OnChainQuery` interface which is satisfied by the new member `onChainQuery` added to the `ErdstallSessoin`. This member should group (future) on-chain functions which are not necessarily associated with Erdstall.