### PR TITLE
deps: Remove fp-ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
 		"eslint-config-prettier": "^8.2.0",
 		"eslint-plugin-prettier": "^3.4.0",
 		"ethereum-waffle": "^3.4.0",
-		"fp-ts": "^1.19.3",
 		"ganache-cli": "^6.12.2",
 		"ganache-core": "^2.13.2",
 		"hardhat": "^2.4.0",

--- a/src/api/util/bigint.ts
+++ b/src/api/util/bigint.ts
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 "use strict";
 
-import { Option, none, some } from "fp-ts/lib/Option";
-
 // `Prettier` has no option to ignore mathexpressions and contrary to whatever
 // `Prettier` is deducing, the statement:
 //
@@ -23,6 +21,7 @@ export function isUint256(value: bigint): value is Uint256 {
 	return value >= 0 && value <= MAX_UINT256;
 }
 
-export function mkUint256(value: bigint): Option<Uint256> {
-	return isUint256(value) ? some(value) : none;
+export function mkUint256(value: bigint): Uint256 {
+	if (!isUint256(value)) throw new Error("given value not a `uint256`");
+	return value;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4083,7 +4083,7 @@ fp-ts@1.19.3:
   resolved "https://registry.npmjs.org/fp-ts/-/fp-ts-1.19.3.tgz"
   integrity sha512-H5KQDspykdHuztLTg+ajGN0Z2qUjcEf3Ybxc6hLt0k7/zPkn29XnKnxlBPyW2XIddWrGaJBzBl4VLYOtk39yZg==
 
-fp-ts@^1.0.0, fp-ts@^1.19.3:
+fp-ts@^1.0.0:
   version "1.19.5"
   resolved "https://registry.npmjs.org/fp-ts/-/fp-ts-1.19.5.tgz"
   integrity sha512-wDNqTimnzs8QqpldiId9OavWK2NptormjXnRJTQecNjzwfyp6P/8s/zG8e4h3ja3oqkKaY72UlTjQYt/1yXf9A==


### PR DESCRIPTION
Removes the `fp-ts` dependency and adapt the implementation where
necessary.