### PR TITLE
test/ledger/env: Allow configuring underlying ganache instance

### DIFF
--- a/src/ledger/backend/ethwrapper.ts
+++ b/src/ledger/backend/ethwrapper.ts
@@ -4,7 +4,6 @@
 // typechain generated events types, which are rather cumbersome to use anyway.
 "use strict";
 
-import { utils } from "ethers";
 import { TypedListener, TypedEventFilter } from "./contracts/commons";
 import { ErdstallEventHandler } from "#erdstall";
 import { Signature } from "#erdstall/api";

--- a/src/test/ledger/env.ts
+++ b/src/test/ledger/env.ts
@@ -5,21 +5,19 @@ import { utils } from "ethers";
 import { ethers } from "ethers";
 import { Wallet } from "ethers";
 import { providers } from "ethers";
-import { deployContract } from "ethereum-waffle";
-import { MockProvider } from "ethereum-waffle";
-
+import { deployContract, MockProvider } from "ethereum-waffle";
 import {
 	Erdstall__factory,
 	PerunArt__factory,
 } from "#erdstall/ledger/backend/contracts";
 import { ETHZERO } from "#erdstall/ledger/assets";
 
-const peruntokenABI = require("../../ledger/backend/contracts/abi/PerunToken.json");
-const erdstallABI = require("../../ledger/backend/contracts/abi/Erdstall.json");
-const erc20holderABI = require("../../ledger/backend/contracts/abi/ERC20Holder.json");
-const erc721holderABI = require("../../ledger/backend/contracts/abi/ERC721Holder.json");
-const ethholderABI = require("../../ledger/backend/contracts/abi/ETHHolder.json");
-const perunArtABI = require("../../ledger/backend/contracts/abi/PerunArt.json");
+import peruntokenABI from "../../ledger/backend/contracts/abi/PerunToken.json";
+import erdstallABI from "../../ledger/backend/contracts/abi/Erdstall.json";
+import erc20holderABI from "../../ledger/backend/contracts/abi/ERC20Holder.json";
+import erc721holderABI from "../../ledger/backend/contracts/abi/ERC721Holder.json";
+import ethholderABI from "../../ledger/backend/contracts/abi/ETHHolder.json";
+import perunArtABI from "../../ledger/backend/contracts/abi/PerunArt.json";
 
 export interface Environment {
 	provider: providers.Web3Provider;
@@ -72,9 +70,12 @@ export async function setupEnv(
 		erc721HolderContract = 5;
 
 	const contractDeployments = [
-		[peruntokenABI, [users.map((u) => u.address), PERUN_FUNDS]],
-		[perunArtABI, [PERUNART_NAME, PERUNART_SYMBOL, PERUNART_URI, []]],
-		[erdstallABI, [tee.address, epochDuration]],
+		[peruntokenABI as any, [users.map((u) => u.address), PERUN_FUNDS]],
+		[
+			perunArtABI as any,
+			[PERUNART_NAME, PERUNART_SYMBOL, PERUNART_URI, []],
+		],
+		[erdstallABI as any, [tee.address, epochDuration]],
 	];
 
 	let nonce: number = await op.getTransactionCount();

--- a/test
+++ b/test
@@ -1,1 +1,0 @@
-src/test

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
     "alwaysStrict": true,                        /* Parse in strict mode and emit "use strict" for each source file. */
 
     "esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "resolveJsonModule": true,
 
     /* Experimental Options */
     "experimentalDecorators": true,              /* Enables experimental support for ES7 decorators. */


### PR DESCRIPTION
This version just exposes the raw ganache configuration struct to be passed as an optional parameter to the setup function of the testenvironment.

There is an argument to be made regarding the _complexity_ of this usage for someone unfamiliar with the stack. It would be easier, but more limiting, to just allow passing a flag like `"automine" | "mineOnTX"` or similar but doing so fixes the blocktime to something **WE** define in our test package. If this also would have to be configurable we would need to expose this too and all other configurations might leak out one by one over time.

This is my argument for this straight forward approach.

EDIT:
Regarding those  `as any` casts after using `import` statements for the contract ABIs: `tsc` has difficulties inferring the correct `abi: any[]` type for the `SimpleContractJSON` type (which is not exported by `ethereum-waffle` :angry: ), thus forcing us to do it like this...