### PR TITLE
Speed up testsetup

### DIFF
--- a/src/ledger/backend/ethwrapper.spec.ts
+++ b/src/ledger/backend/ethwrapper.spec.ts
@@ -94,7 +94,7 @@ describe("ErdstallEventWrapping", function () {
 	let challengedEpoch = 0n;
 	it("wraps challenges", async function () {
 		let timeout: NodeJS.Timeout;
-		challengedEpoch = (await testenv.currentEpoch()) - 1n;
+		challengedEpoch = (await testenv.currentEpoch()) - 2n;
 
 		const res = new Promise((resolve, reject) => {
 			timeout = setTimeout(reject, TIMEOUT_MS);

--- a/src/test/ledger/env.ts
+++ b/src/test/ledger/env.ts
@@ -212,6 +212,9 @@ export async function setupEnv(
 		return bdelta;
 	};
 
+	// seal current epoch!
+	sealEpoch(await currentEpoch());
+
 	return {
 		provider: provider,
 		erdstall: contracts[erdstallContract].address,

--- a/src/test/ledger/env.ts
+++ b/src/test/ledger/env.ts
@@ -58,6 +58,13 @@ export async function setupEnv(
 	const provider = new MockProvider(
 		ganacheOptions ? { ganacheOptions: ganacheOptions } : undefined,
 	);
+
+	const mineBlocks = async (n: number | bigint = 1) => {
+		for (let i = 0; i < n; i++) {
+			await provider.send("evm_mine", []);
+		}
+	};
+
 	const wallets = provider.getWallets();
 
 	const op = wallets[OP];
@@ -85,10 +92,11 @@ export async function setupEnv(
 
 	const deployAndStore = async (deployments: typeof contractDeployments) => {
 		for (const [abi, args] of deployments) {
-			const contract = await deployContract(op, abi, args, {
+			const contract = deployContract(op, abi, args, {
 				nonce: nonce++,
 			});
-			contracts.push(contract);
+			await mineBlocks(8);
+			contracts.push(await contract);
 		}
 	};
 
@@ -114,6 +122,7 @@ export async function setupEnv(
 		const tx = await call(arg1, arg2, {
 			nonce: nonce++,
 		});
+		await mineBlocks();
 		const rec = await tx.wait();
 		if (!rec.status || rec.status !== 1) {
 			Promise.reject(
@@ -163,15 +172,11 @@ export async function setupEnv(
 		op,
 	);
 
+	nonce = await op.getTransactionCount();
 	for (const addr of minters) {
-		await part.addMinter(addr);
+		await part.addMinter(addr, { nonce: nonce++ });
 	}
-
-	const mineBlocks = async (n: number | bigint = 1) => {
-		for (let i = 0; i < n; i++) {
-			await provider.send("evm_mine", []);
-		}
-	};
+	await mineBlocks();
 
 	const currentEpoch = async (): Promise<bigint> => {
 		return Promise.all([


### PR DESCRIPTION
* Speeds up the setup of our test environment
* Ensures the setup finishes with a new epoch starting
* Fixes an oversight in `ethwrapper.spec` where I used `currentEpoch - 1n` to challenge instead of `currentEpoch - 2n`, which only worked because the setup finished in such a way, that the next TX triggered a new epoch :disappointed: 