### PR TITLE
test/env: Decrease pollingInterval on Provider

### DIFF
--- a/src/test/ledger/env.ts
+++ b/src/test/ledger/env.ts
@@ -58,6 +58,7 @@ export async function setupEnv(
 	const provider = new MockProvider(
 		ganacheOptions ? { ganacheOptions: ganacheOptions } : undefined,
 	);
+	provider.pollingInterval = 100;
 
 	const mineBlocks = async (n: number | bigint = 1) => {
 		for (let i = 0; i < n; i++) {


### PR DESCRIPTION
Speeds up tests from ~50s to ~17s.

I also tried using `evm_mine` calls like it is done in the testenv setup but this turned out to be highly inconsistent because any change to the tests (ordering, new testcases etc.) seemed to influence to minimum number of blocks needed for this **hack** to work. So I went with simply reducing the `provider.pollingInterval`.