### PR TITLE
Update to minor version 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@polycrypt/erdstall",
-	"version": "0.1.3",
+	"version": "0.2.0",
 	"description": "SDK to interact with Erdstall Layer-2 Networks",
 	"main": "./index.js",
 	"exports": {


### PR DESCRIPTION
Some Interfacedefinitions and usages changed which results in a breaking API, thus the increase as a `minor` version.