### PR TITLE
Add temporary hack to silence typescript compiler.

### DIFF
--- a/src/crypto/ethereum/signer.ts
+++ b/src/crypto/ethereum/signer.ts
@@ -13,6 +13,8 @@ export class EthereumSigner implements Signer<"ethereum"> {
 	get ethersSigner(): EthersSigner { return this.#ethersSigner; }
 
 	connect(p: Provider) { this.#ethersSigner = this.#ethersSigner.connect(p); }
+	// hack: if typescript makes trouble with a separate import of ethers, use this instead.
+	connect_any(p: any) { this.connect(p as Provider); }
 
 	constructor(ethersSigner: EthersSigner) {
 		this.#ethersSigner = ethersSigner;


### PR DESCRIPTION
Look into why it worked with old versions of node & npm, and why it fails under newer versions. Until then, we can simply use `any`.